### PR TITLE
feat: 검색 시작 페이지 ui 구현

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,5 +1,36 @@
-import React from "react";
+"use client";
+
+import SearchBar from "@/features/search/components/SearchBar";
+import RecommendedSpaces from "@/features/search/components/RecommendedSpaces";
+import SearchResults from "@/features/search/components/SearchResults";
+import { useState } from "react";
+import CurrentLocationButton from "@/features/main/components/CurrentLocationButton";
+import { useRouter } from "next/navigation";
+import ArrowLeftIcon from "@/shared/components/Icons/ArrowLeftIcon";
 
 export default function SearchPage() {
-  return <div>검색 페이지 영역</div>;
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isSearched, setIsSearched] = useState(false);
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+    setIsSearched(true);
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex items-center mb-4">
+        <ArrowLeftIcon onClick={router.back} className="mr-4" />
+        <SearchBar onSearch={handleSearch} />
+        <CurrentLocationButton />
+      </div>
+
+      {isSearched ? (
+        <SearchResults query={searchQuery} />
+      ) : (
+        <RecommendedSpaces />
+      )}
+    </div>
+  );
 }

--- a/src/features/search/components/RecommendedSpaces.tsx
+++ b/src/features/search/components/RecommendedSpaces.tsx
@@ -1,0 +1,71 @@
+import { Divider } from "@/shared/components/Divider";
+import { CloseIcon } from "@/shared/components/Icons";
+import ArrowRightIcon from "@/shared/components/Icons/ArrowRightIcon";
+
+export default function RecommendedSpaces() {
+  const spaces = [
+    {
+      id: 1,
+      name: "서초구 작은음악회 집",
+      description: "월드컵 경기장의 작고 귀여운 아기자기한 키즈카페",
+    },
+    {
+      id: 2,
+      name: "서초구 작은음악회 집",
+      description: "월드컵 경기장의 작고 귀여운 아기자기한 키즈카페",
+    },
+    {
+      id: 3,
+      name: "서초구 작은음악회 집",
+      description: "월드컵 경기장의 작고 귀여운 아기자기한 키즈카페",
+    },
+    {
+      id: 4,
+      name: "서초구 작은음악회 집",
+      description: "월드컵 경기장의 작고 귀여운 아기자기한 키즈카페",
+    },
+    {
+      id: 5,
+      name: "서초구 작은음악회 집",
+      description: "월드컵 경기장의 작고 귀여운 아기자기한 키즈카페",
+    },
+  ];
+
+  return (
+    <div>
+      <div className="flex flex-col mb-3 mt-3">
+        <h2 className="text-xl font-bold mb-3">최근 검색어</h2>
+        <div className="flex bg-gray-100 px-3 py-2 rounded-xl max-w-min whitespace-nowrap text-gray-500">
+          가까운 키즈 카페 <CloseIcon className="ml-1" />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between mb-3 mt-3">
+        <h2 className="text-xl font-bold">추천 장소</h2>
+        <div className="flex items-center">
+          <p className="text-[#8E8E93] text-[15px] font-medium mr-2">
+            모두 보기
+          </p>
+          <ArrowRightIcon className="text-primary" />
+        </div>
+      </div>
+
+      <ul>
+        {spaces.map((space, index) => (
+          <li key={space.id} className="flex flex-col border rounded">
+            <div className="flex  items-center">
+              {" "}
+              <div className="bg-gray-100 min-w-20 h-20 rounded-lg" />
+              <div className="flex flex-col p-4">
+                <h3 className="font-semibold">{space.name}</h3>
+                <p className="text-gray-400">{space.description}</p>
+              </div>
+            </div>
+
+            {index < spaces.length - 1 && <Divider className="mb-2 mt-2" />}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/search/components/SearchBar.tsx
+++ b/src/features/search/components/SearchBar.tsx
@@ -1,0 +1,33 @@
+import CurrentLocationButton from "@/features/main/components/CurrentLocationButton";
+import { SearchIcon } from "@/shared/components/Icons";
+import { useState } from "react";
+
+interface SearchBarProps {
+  onSearch: (query: string) => void;
+}
+
+export default function SearchBar({ onSearch }: SearchBarProps) {
+  const [query, setQuery] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearch(query);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full items-center">
+      <div className="flex justify-between w-full bg-gray-100 px-4 py-2 mr-2 rounded-xl">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="내 주변 베리어프리 놀이터"
+          className="bg-transparent "
+        />
+        <button type="submit">
+          <SearchIcon color="#888" />
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/search/components/SearchResults.tsx
+++ b/src/features/search/components/SearchResults.tsx
@@ -1,0 +1,54 @@
+interface SearchResultsProps {
+  query: string;
+}
+
+export default function SearchResults({ query }: SearchResultsProps) {
+  const results = [
+    {
+      id: 1,
+      name: "공간 이름",
+      description: "아이와아이들이 좋아하는 공간에 대한 설명",
+    },
+    {
+      id: 2,
+      name: "공간 이름",
+      description: "아이와아이들이 좋아하는 공간에 대한 설명",
+    },
+    {
+      id: 3,
+      name: "공간 이름",
+      description: "아이와아이들이 좋아하는 공간에 대한 설명",
+    },
+    {
+      id: 4,
+      name: "공간 이름",
+      description: "아이와아이들이 좋아하는 공간에 대한 설명",
+    },
+    {
+      id: 5,
+      name: "공간 이름",
+      description: "아이와아이들이 좋아하는 공간에 대한 설명",
+    },
+  ];
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">
+        &apos;{query}&apos;에 대한 검색 결과
+      </h2>
+
+      <ul>
+        {results.map((result) => (
+          <li key={result.id} className="mb-4 p-4 border rounded">
+            <h3 className="font-semibold">{result.name}</h3>
+            <p>{result.description}</p>
+            <div className="mt-2 text-sm text-gray-500">
+              <span className="mr-4">⭐ 4.7</span>
+              <span>리뷰 112</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/shared/components/Icons/ArrowLeftIcon.tsx
+++ b/src/shared/components/Icons/ArrowLeftIcon.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { IconProps } from "./types";
+
+export const ArrowLeftIcon = React.forwardRef<SVGSVGElement, IconProps>(
+  ({ color = "currentColor", ...props }, forwardedRef) => {
+    return (
+      <svg
+        width="12"
+        height="21"
+        viewBox="0 0 12 21"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+        ref={forwardedRef}
+      >
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M9.53714 20.0827L0.292152 10.9458C-0.097384 10.5612 -0.097384 9.93981 0.292152 9.5542L9.53714 0.417333C10.0995 -0.139111 11.0144 -0.139111 11.5777 0.417333C12.14 0.973776 12.14 1.87687 11.5777 2.43332L3.66913 10.2505L11.5777 18.0657C12.14 18.6231 12.14 19.5262 11.5777 20.0827C11.0144 20.6391 10.0995 20.6391 9.53714 20.0827Z"
+          fill={color}
+          style={{ mixBlendMode: "color-burn" }}
+        />
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M9.53714 20.0827L0.292152 10.9458C-0.097384 10.5612 -0.097384 9.93981 0.292152 9.5542L9.53714 0.417333C10.0995 -0.139111 11.0144 -0.139111 11.5777 0.417333C12.14 0.973776 12.14 1.87687 11.5777 2.43332L3.66913 10.2505L11.5777 18.0657C12.14 18.6231 12.14 19.5262 11.5777 20.0827C11.0144 20.6391 10.0995 20.6391 9.53714 20.0827Z"
+          fill={color}
+          fill-opacity="0.4"
+        />
+      </svg>
+    );
+  },
+);
+
+ArrowLeftIcon.displayName = "ArrowLeftIcon";
+
+export default ArrowLeftIcon;


### PR DESCRIPTION
## 작업 내용
- /search 경로에 공간 검색 페이지 ui를 구현했습니다.

## 세부 사항
-  검색창 컴포넌트 SearchBar, 검색 결과 컴포넌트 SearchResult.tsx, 추천장소 컴포넌트 RecommendedSpaces 를 새로 추가했습니다.


<img width="322" alt="image" src="https://github.com/user-attachments/assets/0cab9752-da0d-489f-a839-891b9019dfc6">
